### PR TITLE
add downloads folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 venv/
 build/
 dist/
+downloads/
 app.spec


### PR DESCRIPTION
Noticed when testing it out, the _downloads/_ folder would show as tracked by git (shows up as green) when files were downloaded by the app
![Screenshot 2025-04-05 at 4 52 20 PM](https://github.com/user-attachments/assets/bd9bb592-f1bb-41b8-8136-9f8ffb824a79)

This should ensure there's no chance this assets would accidentally get committed to the repo (it is now greyed out), which could be a pain since they will be large and binary.
![Screenshot 2025-04-05 at 4 52 47 PM](https://github.com/user-attachments/assets/b023a2ed-4086-44f3-a163-d6a3bce49b6c)
